### PR TITLE
Graph structure ts

### DIFF
--- a/src/server/neo4j/graphdb-outline-ts.ts
+++ b/src/server/neo4j/graphdb-outline-ts.ts
@@ -72,7 +72,7 @@ const getGraphStructure = async (
   dbAddress: string,
   user: string,
   pass: string
-): Promise<GraphStructure> => {
+): Promise<GraphStructure | undefined> => {
   // create a connection to your neo4j database
   // handles basic authentication and connects to a local host
   const driver: Driver = neo4j.driver(dbAddress, neo4j.auth.basic(user, pass));


### PR DESCRIPTION
To avoid error added undefined type, because promise can return object or undefined