### PR TITLE
Testing and Readonly Query settings

### DIFF
--- a/src/modules/queryRunner.ts
+++ b/src/modules/queryRunner.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
-const fs = require("fs");
-const { parseExtract, extract } = require("./parseExtract.js");
+const fs=require("fs");
+const { parseExtract, extract }=require("./parseExtract.js");
 import neo4j from "neo4j-driver";
 
 export class QueryRunner {
@@ -10,46 +10,38 @@ export class QueryRunner {
   config: any;
 
   constructor(config: any) {
-    this.config = config;
-    this.tChannel = vscode.window.createOutputChannel("Trinity");
+    this.config=config;
+    this.tChannel=vscode.window.createOutputChannel("Trinity");
   }
 
   handleSave(event: vscode.TextDocument) {
     // console logging and reading the file that we have saved and converting it to string
-    const result = parseExtract(fs.readFileSync(event.fileName).toString());
+    const result=parseExtract(fs.readFileSync(event.fileName).toString());
 
     // const resultText = JSON.stringify(result, null, 2);
     // tChannel.appendLine("RESULT ARRAY:\n" + result);
-    const test = "test";
+    const test="test";
 
-    const driver = neo4j.driver(
+    const driver=neo4j.driver(
       this.config.dbAddress,
       neo4j.auth.basic(this.config.username, this.config.password)
     );
-    const session = driver.session();
-    const txc = session.beginTransaction();
-
     // tChannel.appendLine((() => "test")());
     // tChannel.appendLine("Hello");
-    
+
     for (let query of result) {
-      this.tChannel.appendLine(query);
+      const session=driver.session();
       if (!query) {
         this.tChannel.appendLine("Query skipped");
         continue;
       }
-      txc
-        .run(query)
+      session.readTransaction(tx => tx.run(query))
         .then(result => {
+          this.tChannel.appendLine(query);
           this.tChannel.appendLine(
             `Result: ${JSON.stringify(result.records, null, 2)}`
           );
         })
-        // .then(() => {
-        //   vscode.window.showInformationMessage(
-        //     "Trinity: Your Graph Outline is up to Date!"
-        //   );
-        // })
         .catch((err: Error): void => {
           vscode.window.showInformationMessage(
             "Trinity: Please check your query syntax."

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,8 +1,8 @@
 import * as assert from "assert";
 import * as sampleData from "./sampleData.js";
-const { parseExtract } = require("../../modules/parseExtract");
-const { extract } = require("../../modules/parseExtract");
-const { OutlineProvider } = require("../../modules/OutlineProvider");
+const { parseExtract }=require("../../modules/parseExtract");
+const { extract }=require("../../modules/parseExtract");
+const { OutlineProvider }=require("../../modules/OutlineProvider");
 
 //import { expect } from "chai";
 
@@ -14,7 +14,7 @@ import * as vscode from "vscode";
 suite("Extension Test Suite", () => {
   vscode.window.showInformationMessage("Start all tests.");
 
-  const exResultData = {
+  const exResultData={
     graphOutline: [
       { label: "Movie", properties: ["title", "tagline", "released"] },
       { label: "Person", properties: ["born", "name"] }
@@ -34,19 +34,26 @@ suite("Extension Test Suite", () => {
     biDirectionalRelationship: []
   };
 
+  const testConfig={
+    dbAddress: "bolt://localhost",
+    username: "neo4j",
+    password: "test"
+  };
+
+
   test("Sample test", () => {
     assert.equal(-1, [1, 2, 3].indexOf(5));
     assert.equal(-1, [1, 2, 3].indexOf(0));
   });
 
   test("Extract functionality", () => {
-    const extractObj = extract("Trinity('Test') stuff");
+    const extractObj=extract("Trinity('Test') stuff");
     assert.equal(extractObj.queryString, "Test");
     assert.equal(extractObj.currIndex, 14);
   });
 
   test("parseExtract functionality", () => {
-    const queryArray = parseExtract(
+    const queryArray=parseExtract(
       "Trinity('Test') stuff Trinity('anotherTest')"
     );
     assert.equal(queryArray[0], "Test");
@@ -54,8 +61,8 @@ suite("Extension Test Suite", () => {
   });
   //Testing OutlineProvier methods
 
-  const outlineProvider = new OutlineProvider();
-  const exResultObj = outlineProvider.createResultObj(exResultData);
+  const outlineProvider=new OutlineProvider(undefined, testConfig);
+  const exResultObj=outlineProvider.createResultObj(exResultData);
 
   test("OutlineProvider class", () => {
     assert.equal(exResultObj.Person.Properties[0], "born");
@@ -65,7 +72,7 @@ suite("Extension Test Suite", () => {
 
   // testing setUpData method
 
-  const treeData = outlineProvider.setUpData(exResultObj);
+  const treeData=outlineProvider.setUpData(exResultObj);
 
   test("setUpData method", () => {
     assert.equal(treeData[0].label, "Person");


### PR DESCRIPTION
We reconfigured the Neo4j driver to only allow for read only queries. The driver has built in functionality that allows queries to be limited to read only. This will be a default functionality within our application.

We also added a configuration for db inside our test files, due changes we previously made to the outline provider class.